### PR TITLE
Improve UI defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
         <div>Altitude: <span id="altitude-value">0.0</span> m</div>
     </div>
 
+    <div id="keyboard-controls">W A S D - direction<br>Space - thrust<br>Shift - turbo</div>
+
     <div id="loading-indicator" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); color: white; font-size: 24px; font-family: monospace; background-color: rgba(0,0,0,0.7); padding: 20px; border-radius: 5px; display: none; z-index: 20;">Loading Assets...</div>
     <div id="error-message" style="position: absolute; top: 60%; left: 50%; transform: translate(-50%, -50%); color: red; font-size: 18px; font-family: monospace; background-color: rgba(0,0,0,0.8); padding: 15px; border-radius: 5px; display: none; text-align: center; z-index: 20;"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -132,6 +132,7 @@ try {
     explosionFolder.addColor(controlParams, 'explosionColor').onChange(updateExplosionMaterialColor);
     explosionFolder.close();
     gui.add(controlParams, 'cameraSmoothness', 0.01, 0.5, 0.01);
+    gui.close();
 } catch (e) { console.error("Error initializing lil-gui:", e); }
 //---------------------
 

--- a/style.css
+++ b/style.css
@@ -58,6 +58,28 @@ canvas {
     text-align: center;
     z-index: 20; /* Higher than HUD and canvas */
 }
+
+/* Keyboard control hints for desktop */
+#keyboard-controls {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.3);
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-family: sans-serif;
+    font-size: 14px;
+    z-index: 10;
+    opacity: 0.6;
+    display: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  #keyboard-controls {
+    display: block;
+  }
+}
 /* --- End HUD, Loading, Error Styles --- */
 
 /* --- Joystick Zone Styles --- */


### PR DESCRIPTION
## Summary
- keep the lil-gui panel collapsed on page load
- add a subtle desktop-only keyboard control overlay

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ea9be2bac832fb850b01d66ed3f3a